### PR TITLE
[PKG-3565] Initial build v4.7.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - filelock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,9 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 347f23769679aaf7efa73e5655270fcda8ca56be65eb84a4a21d143989541045
+  # Source on pypi is missing files required for tests.
+  url: https://github.com/wkentaro/{{name}}/archive/refs/tags/v{{version}}.tar.gz
+  sha256: 15ba108245126ded919f08cc24550403721c853870dc520e5036366504829cca
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 15ba108245126ded919f08cc24550403721c853870dc520e5036366504829cca
 
 build:
-  noarch: python
+  skip: true # [py<36]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -19,10 +19,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
   run:
-    - python >=3.6
+    - python
     - filelock
     - requests
     - six

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   skip: true # [py<36]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-build-isolation --no-deps -vv
   entry_points:
     - gdown = gdown.cli:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,8 @@ test:
 
 about:
   home: https://github.com/wkentaro/gdown
+  dev_url: https://github.com/wkentaro/gdown
+  doc_url: https://github.com/wkentaro/gdown/blob/main/README.md
   license: MIT
   license_family: MIT
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
   sha256: 15ba108245126ded919f08cc24550403721c853870dc520e5036366504829cca
 
 build:
-  skip: true # [py<36]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-build-isolation --no-deps -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,10 +32,17 @@ requirements:
     - beautifulsoup4
 
 test:
+  requires:
+    - pip
+    - pytest
+  source_files:
+    - tests
   imports:
     - gdown
   commands:
     - gdown --help
+    - pip check
+    - pytest tests
 
 about:
   home: https://github.com/wkentaro/gdown


### PR DESCRIPTION
[PKG-3565](https://anaconda.atlassian.net/browse/PKG-3565)
[Upstream repo](https://github.com/wkentaro/gdown/tree/v4.7.1)

- Downloading from Github rather than pypi to enable upstream tests

[PKG-3565]: https://anaconda.atlassian.net/browse/PKG-3565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ